### PR TITLE
feat(loading-ux): show loading screen before style load

### DIFF
--- a/src/components/LoadingOverlay/index.js
+++ b/src/components/LoadingOverlay/index.js
@@ -5,11 +5,11 @@ import styled from "styled-components";
 const LoadingBackground = styled.div`
   width: 100%;
   height: 100%;
-  background: white;
+  background-color: rgba(255,255,255,.6);
   position: absolute;
   z-index: 1000;
   transition: all 0.5s ease-in-out;
-  display: ${(p) => (p.loading ? "block" : "none")};
+  display: ${(p) => (p.isLoading ? "block" : "none")};
   ${"" /* opacity: ${p => opacityFromState(p.state)}; */}
   ${"" /* display: ${p => (p.state == 'exited') ? 'none' : 'block'}; */}
 `;
@@ -38,9 +38,9 @@ const SpinnerWrapper = styled.div`
 const LoadingOverlay = (p) => {
   const { isLoading } = p;
   return (
-    <LoadingBackground loading={isLoading}>
+    <LoadingBackground isLoading={isLoading}>
       <SpinnerWrapper>
-        <span>Lade Daten ...</span>
+        <span>Daten werden geladen ...</span>
       </SpinnerWrapper>
     </LoadingBackground>
   );

--- a/src/modules/App/AppWrapper.js
+++ b/src/modules/App/AppWrapper.js
@@ -21,7 +21,8 @@ const StyledWrapper = styled(Box)`
 `;
 
 const AppWrapper = () => {
-  const isLoading = useStoreState((state) => state.isLoading);
+  const dataIsLoading = useStoreState((state) => state.dataIsLoading);
+  const styleIsLoading = useStoreState((state) => state.styleIsLoading);
   // const data = useStoreState((state) => state.data);
   const filteredData = useStoreState((state) => state.filteredData);
   const mapCenter = useStoreState((state) => state.mapCenter);
@@ -36,7 +37,7 @@ const AppWrapper = () => {
       <GlobalStyle />
       <DynamicGlobalStyle />
       <StyledWrapper>
-        <LoadingOverlay loading={isLoading} />
+        <LoadingOverlay isLoading={dataIsLoading || styleIsLoading} />
         <Route
           path={["/liste/:itemId", "/liste", "/", "/info"]}
           render={() => <Sidebar data={filteredData} />}

--- a/src/modules/Map/index.js
+++ b/src/modules/Map/index.js
@@ -2,6 +2,7 @@ import React from "react";
 import ReactMapboxGl from "react-mapbox-gl";
 import styled from "styled-components";
 import { withRouter, Route } from "react-router-dom";
+import { useStoreActions } from "easy-peasy";
 
 import MarkerLayer from "./Layer/MarkerLayer";
 import ShadeLayer from "./Layer/ShadeLayer";
@@ -27,6 +28,8 @@ const MapWrapper = styled.div`
 const Map = (p) => {
   const { mapCenter, mapZoom, style, data, selectedShadeData } = p;
 
+  const setStyleIsLoading = useStoreActions((action) => action.setStyleIsLoading);
+
   return (
     <MapWrapper>
       <MapGL
@@ -34,6 +37,7 @@ const Map = (p) => {
         center={mapCenter}
         style={style}
         containerStyle={{ height: "100%", width: "100%" }}
+        onStyleLoad={() => setStyleIsLoading(false)}
       >
         {selectedShadeData && (
           <ShadeLayer

--- a/src/state/models/DataModel.js
+++ b/src/state/models/DataModel.js
@@ -9,7 +9,7 @@ const DataModel = {
   highlightData: false,
   selectedData: false,
   selectedShadeData: null,
-  isLoading: computed((state) => {
+  dataIsLoading: computed((state) => {
     return !state.data && !state.shadeData;
   }),
   loadDataSuccess: action((state, payload) => {

--- a/src/state/models/MapModel.js
+++ b/src/state/models/MapModel.js
@@ -10,6 +10,10 @@ const MapModel = {
   setMapZoom: action((state, payload) => {
     state.mapZoom = payload;
   }),
+  styleIsLoading: true,
+  setStyleIsLoading: action((state, payload) => {
+    state.styleIsLoading = payload;
+  })
 };
 
 export default MapModel;


### PR DESCRIPTION
This PR makes sure that the loading screen is visible while data **and** style are loading.