### PR TITLE
feat: shade zoom

### DIFF
--- a/src/components/ZoomNote.js
+++ b/src/components/ZoomNote.js
@@ -1,0 +1,45 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui";
+// eslint-disable-next-line no-unused-vars
+import React from "react";
+import styled from "styled-components";
+import { useStoreState } from "easy-peasy";
+
+import c from "../config";
+
+const shadesMinZoom = c.map.shades.minZoom;
+
+const StyledWrapper = styled.div`
+  position: absolute;
+  bottom: 15px;
+  right: 15px;
+  width: 250px;
+  box-shadow: 0 2px 40px 0 rgba(30, 55, 145, 0.15);
+  z-index: 3000;
+`;
+
+const ZoomNote = () => {
+  const mapZoom = useStoreState((state) => state.mapZoom);
+  const noteIsVisible = mapZoom[0] < shadesMinZoom;
+  
+  return (
+    <StyledWrapper
+      sx={{
+        display: noteIsVisible ? "block" : "none",
+      }}
+    >
+      <div
+        sx={{
+          fontSize: 1,
+          color: theme => theme.colors.background,
+          backgroundColor: theme => theme.colors.text,
+          padding: [3, 4],
+        }}
+      >
+        Bitte zoome etwas näher, um die Schattenwürfe zu sehen.
+      </div>
+    </StyledWrapper>
+  );
+};
+
+export default ZoomNote;

--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,12 @@ export default {
       accessToken: process.env.REACT_APP_MAP_TOKEN,
       style: process.env.REACT_APP_MAP_STYLE,
     },
+    shades: {
+      tileSize: 256,
+      bounds: [13.1,52.3,13.8,52.7],
+      minZoom: 15,
+      opacity: 0.45,
+    }
   },
   about: {
     legend: {

--- a/src/config.js
+++ b/src/config.js
@@ -10,8 +10,8 @@ export default {
       },
     },
     config: {
-      minZoom: 6,
-      maxZoom: 17,
+      minZoom: 12,
+      maxZoom: 16,
       dragRotate: false,
       bearing: 0,
       maxBounds: [

--- a/src/config.js
+++ b/src/config.js
@@ -11,7 +11,7 @@ export default {
     },
     config: {
       minZoom: 12,
-      maxZoom: 16,
+      maxZoom: 17,
       dragRotate: false,
       bearing: 0,
       maxBounds: [

--- a/src/modules/App/AppWrapper.js
+++ b/src/modules/App/AppWrapper.js
@@ -11,6 +11,7 @@ import Map from "modules/Map";
 import Sidebar from "modules/Sidebar";
 import Nav from "components/Nav";
 import LoadingOverlay from "components/LoadingOverlay";
+import ZoomNote from "components/ZoomNote";
 
 const DynamicGlobalStyle = createGlobalStyle``;
 
@@ -43,6 +44,7 @@ const AppWrapper = () => {
           render={() => <Sidebar data={filteredData} />}
         />
         <Nav />
+        <ZoomNote />
         {filteredData && (
           <Map
             data={filteredData}

--- a/src/modules/Map/Layer/ShadeLayer.js
+++ b/src/modules/Map/Layer/ShadeLayer.js
@@ -1,17 +1,18 @@
 import React from "react";
+import c from "../../../config";
 
 import { Layer, Source } from "react-mapbox-gl";
+
+const { tileSize, bounds, minZoom, opacity } = c.map.shades;
 
 const ShadeLayer = (p) => {
   const { tilesetID } = p;
 
-  const minZoom = 15;
-
   const RASTER_SOURCE_OPTIONS = {
     type: "raster",
     url: `mapbox://${tilesetID}`,
-    tileSize: 256,
-    bounds: [13.1,52.3,13.8,52.7],
+    tileSize: tileSize,
+    bounds: bounds,
   };
 
   const LAYOUT_OPTIONS = {
@@ -19,7 +20,7 @@ const ShadeLayer = (p) => {
   };
 
   const PAINT_OPTIONS = {
-    "raster-opacity":  0.45,
+    "raster-opacity":  opacity,
   };
 
   return (

--- a/src/modules/Map/Layer/ShadeLayer.js
+++ b/src/modules/Map/Layer/ShadeLayer.js
@@ -3,12 +3,15 @@ import React from "react";
 import { Layer, Source } from "react-mapbox-gl";
 
 const ShadeLayer = (p) => {
-  const { tilesetID, isVisible } = p;
+  const { tilesetID } = p;
+
+  const minZoom = 15;
 
   const RASTER_SOURCE_OPTIONS = {
     type: "raster",
     url: `mapbox://${tilesetID}`,
-    tileSize: 512,
+    tileSize: 256,
+    bounds: [13.1,52.3,13.8,52.7],
   };
 
   const LAYOUT_OPTIONS = {
@@ -16,7 +19,7 @@ const ShadeLayer = (p) => {
   };
 
   const PAINT_OPTIONS = {
-    "raster-opacity": isVisible ? 0.45 : 0,
+    "raster-opacity":  0.45,
   };
 
   return (
@@ -28,6 +31,7 @@ const ShadeLayer = (p) => {
         sourceId={tilesetID}
         layout={LAYOUT_OPTIONS}
         paint={PAINT_OPTIONS}
+        minZoom={minZoom}
       />
     </>
   );

--- a/src/modules/Map/index.js
+++ b/src/modules/Map/index.js
@@ -40,10 +40,7 @@ const Map = (p) => {
         onStyleLoad={() => setStyleIsLoading(false)}
       >
         {selectedShadeData && (
-          <ShadeLayer
-            tilesetID={selectedShadeData["tileset_id"]}
-            isVisible={true}
-          />
+          <ShadeLayer tilesetID={selectedShadeData["tileset_id"]} />
         )}
         <Route
           path={["/", "/suche", "/liste", "/favoriten", "/info"]}

--- a/src/modules/Map/index.js
+++ b/src/modules/Map/index.js
@@ -29,6 +29,7 @@ const Map = (p) => {
   const { mapCenter, mapZoom, style, data, selectedShadeData } = p;
 
   const setStyleIsLoading = useStoreActions((action) => action.setStyleIsLoading);
+  const setMapZoom = useStoreActions((action) => action.setMapZoom);
 
   return (
     <MapWrapper>
@@ -38,6 +39,7 @@ const Map = (p) => {
         style={style}
         containerStyle={{ height: "100%", width: "100%" }}
         onStyleLoad={() => setStyleIsLoading(false)}
+        onZoomEnd={(e) => setMapZoom(e.getZoom())}
       >
         {selectedShadeData && (
           <ShadeLayer tilesetID={selectedShadeData["tileset_id"]} />

--- a/src/state/models/MapModel.js
+++ b/src/state/models/MapModel.js
@@ -8,7 +8,7 @@ const MapModel = {
   }),
   mapZoom: c.map.mapZoom,
   setMapZoom: action((state, payload) => {
-    state.mapZoom = payload;
+    state.mapZoom[0] = payload;
   }),
   styleIsLoading: true,
   setStyleIsLoading: action((state, payload) => {


### PR DESCRIPTION
This PR handles the performance issues of the shade layer. It

- updates some settings of the shade layer (e.g. layer boundaries)
- makes the shade layer appear only for higher zoom levels
- displays a note to zoom in if the shade layer is not displayed

Fixes #22 for now.