### PR TITLE
test: render-app test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9194,6 +9194,133 @@
         }
       }
     },
+    "jest-environment-jsdom-fifteen": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom-fifteen/-/jest-environment-jsdom-fifteen-1.0.2.tgz",
+      "integrity": "sha512-nfrnAfwklE1872LIB31HcjM65cWTh1wzvMSp10IYtPJjLDUbTTvDpajZgIxUnhRmzGvogdHDayCIlerLK0OBBg==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^24.3.0",
+        "@jest/fake-timers": "^24.3.0",
+        "@jest/types": "^24.3.0",
+        "jest-mock": "^24.0.0",
+        "jest-util": "^24.0.0",
+        "jsdom": "^15.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "13.0.10",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.10.tgz",
+          "integrity": "sha512-MU10TSgzNABgdzKvQVW1nuuT+sgBMWeXNc3XOs5YXV5SDAK+PPja2eUuBNB9iqElu03xyEDqlnGw0jgl4nbqGQ==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+          "dev": true
+        },
+        "cssstyle": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+          "dev": true,
+          "requires": {
+            "cssom": "~0.3.6"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
+        },
+        "jsdom": {
+          "version": "15.2.1",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+          "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.2.0",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        },
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "dev": true
+        }
+      }
+    },
     "jest-environment-jsdom-fourteen": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jest-environment-jsdom-fourteen/-/jest-environment-jsdom-fourteen-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build && echo '/* /index.html  200' | cat >build/_redirects",
-    "test": "react-scripts test",
+    "test": "react-scripts test --env=jest-environment-jsdom-fifteen",
     "eject": "react-scripts eject",
     "prettier": "prettier",
     "prettier:write": "prettier --write ./src/**/*",
@@ -62,6 +62,7 @@
   "devDependencies": {
     "html-webpack-plugin": "3.2.0",
     "husky": "4.2.5",
+    "jest-environment-jsdom-fifteen": "^1.0.2",
     "lint-staged": "10.2.9",
     "prettier": "1.19.1"
   },

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -1,0 +1,10 @@
+import { render } from "../test-utils";
+
+const { findByText } = render();
+
+describe("App", () => {
+  test("sidebar opens and displays title on initial load", async () => {
+    const titleElement = await findByText(/Berliner Erfrischungskarte/i);
+    expect(titleElement).toBeVisible();
+  });
+});

--- a/src/__tests__/stub.test.js
+++ b/src/__tests__/stub.test.js
@@ -1,5 +1,0 @@
-describe("Just to have some test in here", () => {
-  test("you shall pass", () => {
-    expect(2).toBe(2);
-  });
-});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+window.URL.createObjectURL = function() {};

--- a/src/test-utils.js
+++ b/src/test-utils.js
@@ -1,0 +1,25 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import App from "./modules/App";
+import { Router } from "react-router-dom";
+import { createMemoryHistory } from "history";
+import { StoreProvider } from "easy-peasy";
+import Store from "state/Store";
+
+const allProviders = ({ children }) => {
+  const history = createMemoryHistory();
+  return (
+    <StoreProvider store={Store}>
+      <Router history={history}>
+        <App />
+      </Router>
+    </StoreProvider>
+  )
+}
+
+const customRender = (ui, options) =>
+  render(ui, { wrapper: allProviders, ...options })
+
+export * from "@testing-library/react";
+
+export { customRender as render };


### PR DESCRIPTION
This PR adds a test that checks whether the app gets rendered and the sidebar is expanded on the initial page load. It's a minimal test and closes #13.

To workaround a current [issue with the testing library](https://testing-library.com/docs/react-testing-library/setup#jest-24-or-lower-and-defaults), a specific `jsdom` test environment is specified.