### PR TITLE
chore: specify unsupported devices and browser

### DIFF
--- a/src/components/SupportNote/index.js
+++ b/src/components/SupportNote/index.js
@@ -15,7 +15,7 @@ const SupportNote = (p) => {
         marginBottom: [3, 4],
       }}
     >
-      Teile der Karte können auf einigen Geräten und in einigen Browsern nicht korrekt dargestellt werden. Bitte versuche ein anderes Gerät bzw. einen anderen Browser, um die Karte zu öffnen.
+      Die Schattenwürfe können auf älteren iOS-Geräten und im Safari-Browser aktuell nicht korrekt dargestellt werden. Bitte versuche ein anderes Gerät bzw. einen anderen Browser, um die Karte zu öffnen.
     </div>
   );
 };


### PR DESCRIPTION
This PR makes the support note more specific by naming the devices and browser that do not support the `webp` image format used for the shade tiles.

Fixes #45 