### PR TITLE
feat(SHADOW-22): improve time selector UX

### DIFF
--- a/src/components/TimeSelector/index.js
+++ b/src/components/TimeSelector/index.js
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 //import React from "react";
 import { jsx } from "theme-ui";
-import { makeStyles } from '@material-ui/core/styles';
-import Slider from '@material-ui/core/Slider';
+import { makeStyles } from "@material-ui/core/styles";
+import Slider from "@material-ui/core/Slider";
 import { useStoreState, useStoreActions } from "easy-peasy";
 import { useState } from "react";
 
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 function valuetext(value) {
-  return `${value} Uhr`;
+  return `${value}:00`;
 }
 
 const TimeSelector = (p) => {
@@ -30,21 +30,15 @@ const TimeSelector = (p) => {
 
   const MIN_TIME = shadeData[0]["hour"];
   const MAX_TIME = shadeData[shadeData.length - 1]["hour"];
-  const MORNING_TIME = shadeData.find(shadeInstance => shadeInstance["hour"] === 10)["hour"];
-  const AFTERNOON_TIME = shadeData.find(shadeInstance => shadeInstance["hour"] === 15)["hour"];
 
-  const [ sliderValue, setSliderValue ] = useState(selectedShadeData["hour"]);
+  const [sliderValue, setSliderValue] = useState(selectedShadeData["hour"]);
 
-  const marks = [
-    {
-      value: MORNING_TIME,
-      label: `${valuetext(MORNING_TIME)}`,
-    },
-    {
-      value: AFTERNOON_TIME,
-      label: `${valuetext(AFTERNOON_TIME)}`,
-    },
-  ];
+  const marks = shadeData.map((shadeInstance) => {
+    return {
+      value: shadeInstance["hour"],
+      label: `${valuetext(shadeInstance["hour"])}`,
+    };
+  });
 
   const classes = useStyles();
 
@@ -70,7 +64,7 @@ const TimeSelector = (p) => {
           marginTop: 0,
         }}
       >
-        {valuetext(sliderValue)}
+        {valuetext(sliderValue)} Uhr
       </h2>
       <div className={classes.root}>
         <Slider
@@ -84,7 +78,7 @@ const TimeSelector = (p) => {
           valueLabelDisplay="off"
           marks={marks}
           track={false}
-          onChange={(event, value) => {
+          onChange={(_event, value) => {
             setSliderValue(value);
           }}
           onChangeCommitted={(event, value) => {


### PR DESCRIPTION
This PR improves the UX of the time selector.

It now has marks for all available hours, making it more intuitive that the slider can be moved and to which steps.